### PR TITLE
Add a return line in case no file is retruned from listFiles()

### DIFF
--- a/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
@@ -244,6 +244,7 @@ public abstract class BaseJniExtractor implements JniExtractor {
                 return name.startsWith(prefix) && name.endsWith(suffix);
             }
         });
+        if (files == null) return;
         for (File file : files) {
             // attempt to delete
             try {


### PR DESCRIPTION
Closes #3

Under certain conditions (platform, Java version dependent), `listFiles()` can return `null` causing a NullPointerException.  This PR attempts to fix this error by returning before the for loop is no file is returned.
