### PR TITLE
Allow both .jnilib and .dylib to appear as library extensions for OS X.

### DIFF
--- a/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
@@ -119,11 +119,22 @@ public abstract class BaseJniExtractor implements JniExtractor {
 
         lib = libraryJarClass.getClassLoader().getResource(libPath + mappedlibName);
         if (null == lib) {
+            /*
+             * On OS X, the default mapping changed from .jnilib to .dylib as of JDK 7, so
+             * we need to be prepared for the actual library and mapLibraryName disagreeing
+             * in either direction. 
+             */
             if (mappedlibName.endsWith(".jnilib")) {
                 lib = this.getClass().getClassLoader().getResource(
                         libPath + mappedlibName.substring(0, mappedlibName.length() - 7) + ".dylib");
                 if (null != lib) {
                     mappedlibName = mappedlibName.substring(0, mappedlibName.length() - 7) + ".dylib";
+                }
+            } else if (mappedlibName.endsWith(".dylib")) {
+                lib = this.getClass().getClassLoader().getResource(
+                        libPath + mappedlibName.substring(0, mappedlibName.length() - 6) + ".jnilib");
+                if (null != lib) {
+                    mappedlibName = mappedlibName.substring(0, mappedlibName.length() - 6) + ".jnilib";
                 }
             }
 


### PR DESCRIPTION
As of JDK 7 on OS X, the JNI extension changed from .jnilib to .dylib, so
depending on which version of Java is running and when the library was made,
either extension could be asked for and either of .jnilib or .dylib could
be returned from mapLibraryName, so we need to check for both cases.