### PR TITLE
Decrease the NativeLibraryUtil logging statements to debug level

### DIFF
--- a/src/main/java/org/scijava/nativelib/NativeLibraryUtil.java
+++ b/src/main/java/org/scijava/nativelib/NativeLibraryUtil.java
@@ -292,13 +292,13 @@ public class NativeLibraryUtil {
 				success = true;
 			}
 			catch (final IOException e) {
-				LOGGER.warn("IOException creating DefaultJniExtractor", e);
+				LOGGER.debug("IOException creating DefaultJniExtractor", e);
 			}
 			catch (final SecurityException e) {
-				LOGGER.warn("Can't load dynamic library", e);
+				LOGGER.debug("Can't load dynamic library", e);
 			}
 			catch (final UnsatisfiedLinkError e) {
-				LOGGER.warn("Problem with library", e);
+				LOGGER.debug("Problem with library", e);
 			}
 		}
 		return success;


### PR DESCRIPTION
As the content of these statements are reporting full stack traces and this exceptions are handled by the returned boolean, reporting them at debug level should be sufficient.

/cc @joshmoore 