### PR TITLE
Group extracted files in the same dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,19 @@ Native libraries should be packaged into a single jar file, with the
 following directory & file structure:
 
 ```
-/META-INF
-  /lib
-    /linux_32
-       libxxx[-vvv].so
-    /linux_64
-       libxxx[-vvv].so
-    /osx_32
-       libxxx[-vvv].dylib
-    /osx_64
-       libxxx[-vvv].dylib
-    /windows_32
-       xxx[-vvv].dll
-    /windows_64
-       xxx[-vvv].dll
+/natives
+  /linux_32
+     libxxx[-vvv].so
+  /linux_64
+     libxxx[-vvv].so
+  /osx_32
+     libxxx[-vvv].dylib
+  /osx_64
+     libxxx[-vvv].dylib
+  /windows_32
+     xxx[-vvv].dll
+  /windows_64
+     xxx[-vvv].dll
 ```
 
 Here "xxx" is the name of the native library and "-vvv" is an optional version number.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>17.1.1</version>
+		<version>22.3.0</version>
 		<relativePath />
 	</parent>
 
@@ -112,7 +112,6 @@
 	</ciManagement>
 
 	<properties>
-		<scijava.jvm.version>1.5</scijava.jvm.version>
 		<package-name>org.scijava.nativelib</package-name>
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>Board of Regents of the University of
@@ -124,7 +123,6 @@ Wisconsin-Madison and Glencoe Software, Inc.</license.copyrightOwners>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.6</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
@@ -59,7 +59,7 @@ public abstract class BaseJniExtractor implements JniExtractor {
 	private static final Logger LOGGER = LoggerFactory.getLogger(
 		"org.scijava.nativelib.BaseJniExtractor");
 	protected static final String JAVA_TMPDIR = "java.io.tmpdir";
-	protected static final String ALTR_TMPDIR = "./tmplib";
+	protected static final String ALTR_TMPDIR = "."+ NativeLibraryUtil.DELIM + "tmplib";
 	protected static final String TMP_PREFIX = "nativelib-loader_";
 	private static final String LEFTOVER_MIN_AGE = "org.scijava.nativelib.leftoverMinAgeMs";
 	private static final long LEFTOVER_MIN_AGE_DEFAULT = 5 * 60 * 1000; // 5 minutes
@@ -89,10 +89,10 @@ public abstract class BaseJniExtractor implements JniExtractor {
 
 		if (mxSysInfo != null) {
 			nativeResourcePaths =
-				new String[] { "META-INF/lib/" + mxSysInfo + "/", "META-INF/lib/" };
+				new String[] { "natives/", "META-INF/lib/" + mxSysInfo + "/", "META-INF/lib/" };
 		}
 		else {
-			nativeResourcePaths = new String[] { "META-INF/lib/" };
+			nativeResourcePaths = new String[] { "natives/", "META-INF/lib/" };
 		}
 		// clean up leftover libraries from previous runs
 		deleteLeftoverFiles();
@@ -158,8 +158,8 @@ public abstract class BaseJniExtractor implements JniExtractor {
 		}
 
 		// foolproof
-		String combinedPath = (libPath.equals("") || libPath.endsWith("/") ?
-				libPath : libPath + "/") + mappedlibName;
+		String combinedPath = (libPath.equals("") || libPath.endsWith(NativeLibraryUtil.DELIM) ?
+				libPath : libPath + NativeLibraryUtil.DELIM) + mappedlibName;
 		lib = libraryJarClass.getClassLoader().getResource(combinedPath);
 		if (null == lib) {
 			/*
@@ -193,7 +193,7 @@ public abstract class BaseJniExtractor implements JniExtractor {
 			return extractResource(getJniDir(), lib, mappedlibName);
 		}
 		LOGGER.info("Couldn't find resource " + combinedPath);
-		throw new IOException("Couldn't find resource " + combinedPath);
+		return null;
 	}
 
 	/** {@inheritDoc} */

--- a/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
@@ -158,7 +158,8 @@ public abstract class BaseJniExtractor implements JniExtractor {
 		}
 
 		// foolproof
-		String combinedPath = (libPath.endsWith("/") ? libPath : libPath + "/") + mappedlibName;
+		String combinedPath = (libPath.equals("") || libPath.endsWith("/") ?
+				libPath : libPath + "/") + mappedlibName;
 		lib = libraryJarClass.getClassLoader().getResource(combinedPath);
 		if (null == lib) {
 			/*

--- a/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
@@ -157,7 +157,9 @@ public abstract class BaseJniExtractor implements JniExtractor {
 			libraryJarClass = this.getClass();
 		}
 
-		lib = libraryJarClass.getClassLoader().getResource(libPath + mappedlibName);
+		// foolproof
+		String combinedPath = (libPath.endsWith("/") ? libPath : libPath + "/") + mappedlibName;
+		lib = libraryJarClass.getClassLoader().getResource(combinedPath);
 		if (null == lib) {
 			/*
 			 * On OS X, the default mapping changed from .jnilib to .dylib as of JDK 7, so
@@ -189,10 +191,8 @@ public abstract class BaseJniExtractor implements JniExtractor {
 			LOGGER.debug("URL path is " + lib.getPath());
 			return extractResource(getJniDir(), lib, mappedlibName);
 		}
-		LOGGER.info("Couldn't find resource " + libPath + " " +
-			mappedlibName);
-		throw new IOException("Couldn't find resource " + libPath + " " +
-			mappedlibName);
+		LOGGER.info("Couldn't find resource " + combinedPath);
+		throw new IOException("Couldn't find resource " + combinedPath);
 	}
 
 	/** {@inheritDoc} */

--- a/src/main/java/org/scijava/nativelib/DefaultJniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/DefaultJniExtractor.java
@@ -38,9 +38,6 @@ package org.scijava.nativelib;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * JniExtractor suitable for single application deployments per virtual machine
@@ -57,29 +54,10 @@ public class DefaultJniExtractor extends BaseJniExtractor {
 	 */
 	private File nativeDir;
 
-	public DefaultJniExtractor() throws IOException {
-		super(null);
-		init(ALTR_TMPDIR);
-	}
-
-	public DefaultJniExtractor(final Class<?> libraryJarClass, final String tmplib)
-		throws IOException
-	{
+	public DefaultJniExtractor(final Class<?> libraryJarClass) throws IOException {
 		super(libraryJarClass);
-		init(tmplib);
-	}
 
-	void init(final String tmplib) throws IOException {
-		// If system temporary directory is not available, use tmplib
-		Path tmpDir = Paths.get(System.getProperty(JAVA_TMPDIR, tmplib));
-		if (!Files.isDirectory(tmpDir)) {
-			tmpDir.toFile().mkdirs();
-			if (!Files.isDirectory(tmpDir)) {
-				throw new IOException(
-					"Unable to create temporary directory " + tmpDir);
-			}
-		}
-		nativeDir = Files.createTempDirectory(tmpDir, TMP_PREFIX).toFile();
+		nativeDir = getTempDir();
 		// Order of operations is such that we do not error if we are racing with
 		// another thread to create the directory.
 		nativeDir.mkdirs();

--- a/src/main/java/org/scijava/nativelib/DefaultJniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/DefaultJniExtractor.java
@@ -38,6 +38,9 @@ package org.scijava.nativelib;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * JniExtractor suitable for single application deployments per virtual machine
@@ -56,7 +59,7 @@ public class DefaultJniExtractor extends BaseJniExtractor {
 
 	public DefaultJniExtractor() throws IOException {
 		super(null);
-		init("tmplib");
+		init(ALTR_TMPDIR);
 	}
 
 	public DefaultJniExtractor(final Class<?> libraryJarClass, final String tmplib)
@@ -67,7 +70,16 @@ public class DefaultJniExtractor extends BaseJniExtractor {
 	}
 
 	void init(final String tmplib) throws IOException {
-		nativeDir = new File(System.getProperty("java.library.tmpdir", tmplib));
+		// If system temporary directory is not available, use tmplib
+		Path tmpDir = Paths.get(System.getProperty(JAVA_TMPDIR, tmplib));
+		if (!Files.isDirectory(tmpDir)) {
+			tmpDir.toFile().mkdirs();
+			if (!Files.isDirectory(tmpDir)) {
+				throw new IOException(
+					"Unable to create temporary directory " + tmpDir);
+			}
+		}
+		nativeDir = Files.createTempDirectory(tmpDir, TMP_PREFIX).toFile();
 		// Order of operations is such that we do not error if we are racing with
 		// another thread to create the directory.
 		nativeDir.mkdirs();
@@ -75,6 +87,7 @@ public class DefaultJniExtractor extends BaseJniExtractor {
 			throw new IOException(
 				"Unable to create native library working directory " + nativeDir);
 		}
+		nativeDir.deleteOnExit();
 	}
 
 	@Override

--- a/src/main/java/org/scijava/nativelib/NativeLibraryUtil.java
+++ b/src/main/java/org/scijava/nativelib/NativeLibraryUtil.java
@@ -83,7 +83,6 @@ public class NativeLibraryUtil {
 
 	private static Architecture architecture = Architecture.UNKNOWN;
 	private static final String DELIM = "/";
-	private static final String JAVA_TMPDIR = "java.io.tmpdir";
 	private static final Logger LOGGER = LoggerFactory.getLogger(
 		"org.scijava.nativelib.NativeLibraryUtil");
 
@@ -288,10 +287,8 @@ public class NativeLibraryUtil {
 		}
 		else {
 			try {
-				// will extract library to temporary directory
-				final String tmpDirectory = System.getProperty(JAVA_TMPDIR);
 				final JniExtractor jniExtractor =
-					new DefaultJniExtractor(libraryJarClass, tmpDirectory);
+					new DefaultJniExtractor(libraryJarClass);
 
 				// do extraction
 				final File extractedFile =

--- a/src/main/java/org/scijava/nativelib/NativeLibraryUtil.java
+++ b/src/main/java/org/scijava/nativelib/NativeLibraryUtil.java
@@ -81,8 +81,11 @@ public class NativeLibraryUtil {
 		UNKNOWN, INTEL_32, INTEL_64, PPC, ARM, AARCH_64
 	}
 
+	public static final String DELIM = "/";
+	public static final String DEFAULT_SEARCH_PATH = "natives" + DELIM;
+
 	private static Architecture architecture = Architecture.UNKNOWN;
-	private static final String DELIM = "/";
+	private static String archStr = null;
 	private static final Logger LOGGER = LoggerFactory.getLogger(
 		"org.scijava.nativelib.NativeLibraryUtil");
 
@@ -171,14 +174,22 @@ public class NativeLibraryUtil {
 
 	/**
 	 * Returns the path to the native library.
+	 * 
+	 * @param searchPath the path to search for &lt;platform&gt; directory.
+	 * 			Pass in <code>null</code> to get default path
+	 * 			(natives/&lt;platform&gt;).
 	 *
 	 * @return path
 	 */
-	public static String getPlatformLibraryPath() {
-		String path = "META-INF" + DELIM + "lib" + DELIM;
-		path += getArchitecture().name().toLowerCase() + DELIM;
-		LOGGER.debug("platform specific path is " + path);
-		return path;
+	public static String getPlatformLibraryPath(String searchPath) {
+		if (archStr == null)
+			archStr = NativeLibraryUtil.getArchitecture().name().toLowerCase();
+
+		// foolproof
+		String fullSearchPath = (searchPath.equals("") || searchPath.endsWith(DELIM) ?
+				searchPath : searchPath + DELIM) + archStr + DELIM;
+		LOGGER.debug("platform specific path is " + fullSearchPath);
+		return fullSearchPath;
 	}
 
 	/**
@@ -203,6 +214,8 @@ public class NativeLibraryUtil {
 			case OSX_32:
 			case OSX_64:
 				name = "lib" + libName + ".dylib";
+				break;
+			default:
 				break;
 		}
 		LOGGER.debug("native library name " + name);
@@ -292,7 +305,7 @@ public class NativeLibraryUtil {
 
 				// do extraction
 				final File extractedFile =
-					jniExtractor.extractJni(getPlatformLibraryPath(), libName);
+					jniExtractor.extractJni(getPlatformLibraryPath(null), libName);
 
 				// load extracted library from temporary directory
 				System.load(extractedFile.getPath());

--- a/src/main/java/org/scijava/nativelib/NativeLibraryUtil.java
+++ b/src/main/java/org/scijava/nativelib/NativeLibraryUtil.java
@@ -194,7 +194,7 @@ public class NativeLibraryUtil {
 			case LINUX_64:
 			case LINUX_ARM:
 			case LINUX_ARM64:
-				name = libName + ".so";
+				name = "lib" + libName + ".so";
 				break;
 			case WINDOWS_32:
 			case WINDOWS_64:

--- a/src/main/java/org/scijava/nativelib/NativeLoader.java
+++ b/src/main/java/org/scijava/nativelib/NativeLoader.java
@@ -122,8 +122,9 @@ public class NativeLoader {
 	 *           specified dynamic library
 	 */
 	public static void loadLibrary(final String libname) throws IOException {
-		// TODO pass in library path or get rid of this method
-		System.load(jniExtractor.extractJni("", libname).getAbsolutePath());
+		String libPath = String.format("META-INF/lib/%s",
+				NativeLibraryUtil.getArchitecture().name().toLowerCase());
+		System.load(jniExtractor.extractJni(libPath, libname).getAbsolutePath());
 	}
 
 	/**

--- a/src/main/java/org/scijava/nativelib/NativeLoader.java
+++ b/src/main/java/org/scijava/nativelib/NativeLoader.java
@@ -122,9 +122,14 @@ public class NativeLoader {
 	 *           specified dynamic library
 	 */
 	public static void loadLibrary(final String libname) throws IOException {
-		String libPath = String.format("META-INF/lib/%s",
-				NativeLibraryUtil.getArchitecture().name().toLowerCase());
-		System.load(jniExtractor.extractJni(libPath, libname).getAbsolutePath());
+		try {
+			// try to load library from classpath
+			System.loadLibrary(libname);
+		} catch (UnsatisfiedLinkError e) {
+			String libPath = String.format("META-INF/lib/%s",
+					NativeLibraryUtil.getArchitecture().name().toLowerCase());
+			System.load(jniExtractor.extractJni(libPath, libname).getAbsolutePath());
+		}
 	}
 
 	/**

--- a/src/main/java/org/scijava/nativelib/NativeLoader.java
+++ b/src/main/java/org/scijava/nativelib/NativeLoader.java
@@ -97,7 +97,7 @@ public class NativeLoader {
 			if (NativeLoader.class.getClassLoader() == ClassLoader
 				.getSystemClassLoader())
 			{
-				jniExtractor = new DefaultJniExtractor();
+				jniExtractor = new DefaultJniExtractor(null);
 			}
 			else {
 				jniExtractor = new WebappJniExtractor("Classloader");

--- a/src/main/java/org/scijava/nativelib/WebappJniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/WebappJniExtractor.java
@@ -38,9 +38,6 @@ package org.scijava.nativelib;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * JniExtractor suitable for multiple application deployments on the same
@@ -69,16 +66,7 @@ public class WebappJniExtractor extends BaseJniExtractor {
 	 *          subdirectory which will be created.
 	 */
 	public WebappJniExtractor(final String classloaderName) throws IOException {
-		// If system temporary directory is not available, use tmplib
-		Path tmpDir = Paths.get(System.getProperty(JAVA_TMPDIR, ALTR_TMPDIR));
-		if (!Files.isDirectory(tmpDir)) {
-			tmpDir.toFile().mkdirs();
-			if (!Files.isDirectory(tmpDir)) {
-				throw new IOException(
-					"Unable to create temporary directory " + tmpDir);
-			}
-		}
-		nativeDir = Files.createTempDirectory(tmpDir, TMP_PREFIX).toFile();
+		nativeDir = getTempDir();
 		// Order of operations is such thatwe do not error if we are racing with
 		// another thread to create the directory.
 		nativeDir.mkdirs();

--- a/src/main/java/org/scijava/nativelib/WebappJniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/WebappJniExtractor.java
@@ -38,6 +38,9 @@ package org.scijava.nativelib;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * JniExtractor suitable for multiple application deployments on the same
@@ -66,7 +69,16 @@ public class WebappJniExtractor extends BaseJniExtractor {
 	 *          subdirectory which will be created.
 	 */
 	public WebappJniExtractor(final String classloaderName) throws IOException {
-		nativeDir = new File(System.getProperty("java.library.tmpdir", "tmplib"));
+		// If system temporary directory is not available, use tmplib
+		Path tmpDir = Paths.get(System.getProperty(JAVA_TMPDIR, ALTR_TMPDIR));
+		if (!Files.isDirectory(tmpDir)) {
+			tmpDir.toFile().mkdirs();
+			if (!Files.isDirectory(tmpDir)) {
+				throw new IOException(
+					"Unable to create temporary directory " + tmpDir);
+			}
+		}
+		nativeDir = Files.createTempDirectory(tmpDir, TMP_PREFIX).toFile();
 		// Order of operations is such thatwe do not error if we are racing with
 		// another thread to create the directory.
 		nativeDir.mkdirs();

--- a/src/test/java/org/scijava/nativelib/NativeLoaderTest.java
+++ b/src/test/java/org/scijava/nativelib/NativeLoaderTest.java
@@ -59,7 +59,7 @@ public class NativeLoaderTest {
 		JarOutputStream target = new JarOutputStream(new FileOutputStream(dummyJar), manifest);
 
 		// with a dummy binary in it
-		File source = new File(String.format("META-INF/lib/%s/%s",
+		File source = new File(String.format("natives/%s/%s",
 				NativeLibraryUtil.getArchitecture().name().toLowerCase(),
 				NativeLibraryUtil.getPlatformLibraryName("dummy")));
 		JarEntry entry = new JarEntry(source.getPath().replace("\\", "/"));
@@ -92,7 +92,7 @@ public class NativeLoaderTest {
 		createJar();
 		// see if dummy is correctly extracted
 		JniExtractor jniExtractor = new DefaultJniExtractor(null);
-		String libPath = String.format("META-INF/lib/%s",
+		String libPath = String.format("natives/%s",
 				NativeLibraryUtil.getArchitecture().name().toLowerCase());
 		File extracted = jniExtractor.extractJni(libPath + "", "dummy");
 


### PR DESCRIPTION
Added one more layer of temporary folder to contain the extracted files so that they are not named with a timestamp appended, which prevents multiple lib files to find each other by name.

All files/folders in the jar are extracted to a folder named nativelib-loader__timestamp_ under system temp dir specified by `java.io.tmpdir` or this folder under the runtime directory if `java.io.tmpdir` is not set.