### PR TITLE
Fix NPE with NativeLibraryUtil.loadNativeLibrary()

### DIFF
--- a/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
@@ -192,7 +192,7 @@ public abstract class BaseJniExtractor implements JniExtractor {
 			LOGGER.debug("URL path is " + lib.getPath());
 			return extractResource(getJniDir(), lib, mappedlibName);
 		}
-		LOGGER.info("Couldn't find resource " + combinedPath);
+		LOGGER.debug("Couldn't find resource " + combinedPath);
 		return null;
 	}
 

--- a/src/main/java/org/scijava/nativelib/JniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/JniExtractor.java
@@ -50,7 +50,7 @@ public interface JniExtractor {
 	 * @param libPath library path
 	 * @param libname System.loadLibrary() compatible library name
 	 * @return the extracted file
-	 * @throws IOException
+	 * @throws IOException when extracting the desired file failed
 	 */
 	public File extractJni(String libPath, String libname) throws IOException;
 
@@ -58,7 +58,7 @@ public interface JniExtractor {
 	 * Extract all libraries which are registered for auto-extraction to files in
 	 * the temporary directory.
 	 * 
-	 * @throws IOException
+	 * @throws IOException when extracting the desired file failed
 	 */
 	public void extractRegistered() throws IOException;
 }

--- a/src/main/java/org/scijava/nativelib/MxSysInfo.java
+++ b/src/main/java/org/scijava/nativelib/MxSysInfo.java
@@ -41,6 +41,8 @@ public class MxSysInfo {
 	 * Find the mx.sysinfo string for the current jvm
 	 * <p>
 	 * Can be overridden by specifying a mx.sysinfo system property
+	 * 
+	 * @return the specified mx.sysinfo or a guessed one
 	 */
 	public static String getMxSysInfo() {
 		final String mxSysInfo = System.getProperty("mx.sysinfo");
@@ -50,6 +52,8 @@ public class MxSysInfo {
 	/**
 	 * Make a spirited attempt at guessing what the mx.sysinfo for the current jvm
 	 * might be.
+	 * 
+	 * @return the guessed mx.sysinfo
 	 */
 	public static String guessMxSysInfo() {
 		final String arch = System.getProperty("os.arch");

--- a/src/main/java/org/scijava/nativelib/NativeLoader.java
+++ b/src/main/java/org/scijava/nativelib/NativeLoader.java
@@ -36,11 +36,7 @@
 
 package org.scijava.nativelib;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * Provides a means of loading JNI libraries which are stored within a jar.
@@ -132,38 +128,17 @@ public class NativeLoader {
 	 *           <code>checkLink</code> method doesn't allow loading of the
 	 *           specified dynamic library
 	 */
-	public static void loadLibrary(final String libname, final String... searchPaths)
+	public static void loadLibrary(final String libName, final String... searchPaths)
 			throws IOException {
 		try {
 			// try to load library from classpath
-			System.loadLibrary(libname);
+			System.loadLibrary(libName);
 			return;
 		} catch (UnsatisfiedLinkError e) {
-			List<String> libPaths = searchPaths == null ?
-					new LinkedList<String>() :
-					new LinkedList<String>(Arrays.asList(searchPaths));
-			libPaths.add(0, NativeLibraryUtil.DEFAULT_SEARCH_PATH);
-			// for backward compatibility
-			libPaths.add(1, "");
-			libPaths.add(2, "META-INF" + NativeLibraryUtil.DELIM + "lib");
-			// NB: Although the documented behavior of this method is to load
-			// native library from META-INF/lib/, what it actually does is
-			// to load from the root dir. See: https://github.com/scijava/
-			// native-lib-loader/blob/6c303443cf81bf913b1732d42c74544f61aef5d1/
-			// src/main/java/org/scijava/nativelib/NativeLoader.java#L126
-
-			// search in each path in {natives/, /, META-INF/lib/, ...}
-			for (String libPath : libPaths) {
-				File extracted = jniExtractor.extractJni(
-						NativeLibraryUtil.getPlatformLibraryPath(libPath),
-						libname);
-				if (extracted != null) {
-					System.load(extracted.getAbsolutePath());
-					return;
-				}
-			}
+			if (NativeLibraryUtil.loadNativeLibrary(jniExtractor, libName, searchPaths))
+				return;
 		}
-		throw new IOException("Couldn't load library library " + libname);
+		throw new IOException("Couldn't load library library " + libName);
 	}
 
 	/**

--- a/src/main/java/org/scijava/nativelib/NativeLoader.java
+++ b/src/main/java/org/scijava/nativelib/NativeLoader.java
@@ -118,7 +118,7 @@ public class NativeLoader {
 	 * &lt;platform&gt;/&lt;lib_binary&gt; will be searched in the root,
 	 * META-INF/lib/ and <code>searchPaths</code>.
 	 * 
-	 * @param libname platform-independent library name (as would be passed to
+	 * @param libName platform-independent library name (as would be passed to
 	 *          System.loadLibrary)
 	 * @param searchPaths a list of additional paths relative to the jar's root
 	 * 			to search for the specified native library in case it does not


### PR DESCRIPTION
This PR resolves the problem of throwing NPE when [`loci.formats.services.JPEGTurboServiceImpl`](https://github.com/openmicroscopy/bioformats/blob/7e83ee90121b64cea014b2475edd5729db0ddc56/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java#L107) is trying to load `turbojpeg` by calling `NativeLibraryUtil.loadNativeLibrary()` directly.

The body of `NativeLibraryUtil.loadNativeLibrary()` is lifted from `NativeLibLoader.load()`.