### PR TITLE
Add support for Android 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ following directory & file structure:
      xxx[-vvv].dll
   /windows_64
      xxx[-vvv].dll
+  /aix_32
+     libxxx[-vvv].so
+     libxxx[-vvv].a
+  /aix_64
+     libxxx[-vvv].so
+     libxxx[-vvv].a
 ```
 
 Here "xxx" is the name of the native library and "-vvv" is an optional version number.
@@ -60,7 +66,7 @@ convention.
 
 ### Load library
 
-If you want to load 'awesome.dll' (on Windows) or 'libawesome.so' (on Linux),
+If you want to load 'awesome.dll' (on Windows) or 'libawesome.so' (on Linux or AIX),
 simply do like this ...
 
 ```Java

--- a/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
@@ -45,7 +45,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.URL;
-import java.nio.file.Files;
 import java.util.Enumeration;
 
 import org.slf4j.Logger;
@@ -122,7 +121,10 @@ public abstract class BaseJniExtractor implements JniExtractor {
 			if (!tmpDir.isDirectory())
 				throw new IOException("Unable to create temporary directory " + tmpDir);
 		}
-		return Files.createTempDirectory(tmpDir.toPath(), TMP_PREFIX).toFile();
+
+		File tempFile = File.createTempFile(TMP_PREFIX, "");
+		tempFile.delete();
+		return tempFile;
 	}
 
 	/**

--- a/src/main/java/org/scijava/nativelib/NativeLibraryUtil.java
+++ b/src/main/java/org/scijava/nativelib/NativeLibraryUtil.java
@@ -323,7 +323,7 @@ public class NativeLibraryUtil {
 		else {
 			try {
 				final List<String> libPaths = searchPaths == null ?
-						new LinkedList<>() :
+						new LinkedList<String>() :
 						new LinkedList<>(Arrays.asList(searchPaths));
 				libPaths.add(0, NativeLibraryUtil.DEFAULT_SEARCH_PATH);
 				// for backward compatibility


### PR DESCRIPTION
According to #26 there is a problem with loading libraries as Android 6 (general Android OS with api version below 26) doesn't support java.nio.file.

So in this PR I tried to fix that issue.
Result of tests:
- Android - OK
- Windows - OK
- Linux - OK (Debian 8)
- MacOS - OK

Additionally I added some minor changes in README.md regarding #25

Last change is an attempt to keep supporting Java 7 for project building.
So I added type to one List diamond.

Cheers.