### PR TITLE
Java 6 compatiblity. fixes #28.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,11 @@
 		<license.copyrightOwners>Board of Regents of the University of
 Wisconsin-Madison and Glencoe Software, Inc.</license.copyrightOwners>
 		<license.projectName>Native library loader for extracting and loading native libraries from Java.</license.projectName>
-		<scijava.jvm.version>1.7</scijava.jvm.version>
+		<scijava.jvm.version>1.6</scijava.jvm.version>
+		<maven.compiler.source>1.6</maven.compiler.source>
+		<maven.compiler.target>1.6</maven.compiler.target>
+		<plugin.animalsniffer.version>1.17</plugin.animalsniffer.version>
+
 	</properties>
 
 	<dependencies>
@@ -131,4 +135,32 @@ Wisconsin-Madison and Glencoe Software, Inc.</license.copyrightOwners>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+
+	<build>
+		<plugins>
+			<!-- check for java 6 compatiblity -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>animal-sniffer-maven-plugin</artifactId>
+				<version>${plugin.animalsniffer.version}</version>
+				<configuration>
+					<signature>
+					<groupId>org.codehaus.mojo.signature</groupId>
+					<artifactId>java16</artifactId>
+					<version>1.1</version>
+					</signature>
+				</configuration>
+				<executions>
+					<execution>
+					<id>ensure-java-1.6-class-library</id>
+					<phase>verify</phase>
+					<goals>
+						<goal>check</goal>
+					</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
+++ b/src/main/java/org/scijava/nativelib/BaseJniExtractor.java
@@ -259,7 +259,9 @@ public abstract class BaseJniExtractor implements JniExtractor {
 	File extractResource(final File dir, final URL resource,
 		final String outputName) throws IOException
 	{
-		try (final InputStream in = resource.openStream()) {
+		InputStream in = null;
+		try {
+			in = resource.openStream();
 			// TODO there's also a getResourceAsStream
 
 			// make a lib file with exactly the same lib name
@@ -268,15 +270,20 @@ public abstract class BaseJniExtractor implements JniExtractor {
 				outfile.getAbsolutePath() + "'");
 
 			// copy resource stream to temporary file
-			try (final FileOutputStream out = new FileOutputStream(outfile)) {
+			FileOutputStream out = null;
+			try {
+				out = new FileOutputStream(outfile);
 				copy(in, out);
-				out.close();
+			} finally {
+				if (out != null) { out.close(); }
 			}
 
 			// note that this doesn't always work:
 			outfile.deleteOnExit();
 
 			return outfile;
+		} finally {
+			if (in != null) { in.close(); }
 		}
 	}
 

--- a/src/main/java/org/scijava/nativelib/NativeLibraryUtil.java
+++ b/src/main/java/org/scijava/nativelib/NativeLibraryUtil.java
@@ -324,7 +324,7 @@ public class NativeLibraryUtil {
 			try {
 				final List<String> libPaths = searchPaths == null ?
 						new LinkedList<String>() :
-						new LinkedList<>(Arrays.asList(searchPaths));
+						new LinkedList<String>(Arrays.asList(searchPaths));
 				libPaths.add(0, NativeLibraryUtil.DEFAULT_SEARCH_PATH);
 				// for backward compatibility
 				libPaths.add(1, "");

--- a/src/test/java/org/scijava/nativelib/NativeLoaderTest.java
+++ b/src/test/java/org/scijava/nativelib/NativeLoaderTest.java
@@ -56,7 +56,9 @@ public class NativeLoaderTest {
 		File dummyJar = tmpTestDir.newFile("dummy.jar");
 		Manifest manifest = new Manifest();
 		manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
-		try (final JarOutputStream target = new JarOutputStream(new FileOutputStream(dummyJar), manifest)) {
+		JarOutputStream target = null;
+		try {
+			target = new JarOutputStream(new FileOutputStream(dummyJar), manifest);
 
 			// with a dummy binary in it
 			File source = new File(String.format("natives/%s/%s",
@@ -70,6 +72,8 @@ public class NativeLoaderTest {
 			byte[] buffer = "native-lib-loader".getBytes();
 			target.write(buffer, 0, buffer.length);
 			target.closeEntry();
+		} finally {
+			if (target != null) { target.close(); }
 		}
 
 		// and add to classpath as if it is a dependency of the project
@@ -96,10 +100,14 @@ public class NativeLoaderTest {
 				NativeLibraryUtil.getArchitecture().name().toLowerCase());
 		File extracted = jniExtractor.extractJni(libPath + "", "dummy");
 
-		try (final FileInputStream in = new FileInputStream(extracted)) {
+		FileInputStream in = null;
+		try {
+			in = new FileInputStream(extracted);
 			byte[] buffer = new byte[32];
 			in.read(buffer, 0, buffer.length);
 			assertTrue(new String(buffer).trim().equals("native-lib-loader"));
+		} finally {
+			if (in != null) { in.close(); }
 		}
 	}
 }


### PR DESCRIPTION
Please kindly accept this pull request for Java 6 compatiblity. There is a project (https://github.com/java-native/java-simple-serial-connector) which needs Java 6 support for another year or so, and there is no reason this library wouldn‘t be able to support this easily.

I know, Java 6 is out of support, but you can still run Java 6 code with Java 8 or Java 11. :-)

The project can still be compiled using Java 8 to Java 11.

## Changelog

  - Removed a diamond operator.
  - Removed 5 try-with-resources (3 in main, 2 in test).
  - Added the animal sniffer plugin to check the usage of Java API.
  - Set the maven compiler source and target