### PR TITLE
POM: add missing dependency slf4j-simple

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,10 @@ Wisconsin-Madison and Glencoe Software, Inc.</license.copyrightOwners>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@ Wisconsin-Madison and Glencoe Software, Inc.</license.copyrightOwners>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
+			<artifactId>slf4j-nop</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
This dependency is required for SLF4J to properly function. Although the current implementation does not involve serious logging, the annoying error "Failed to load class `org.slf4j.impl.StaticLoggerBinder`" pops up in multiple dependent projects as slf4j-simple is missing. See [this doc](https://www.slf4j.org/codes.html#StaticLoggerBinder).